### PR TITLE
Locked dbt-utils to version 0.3.0

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: fishtown-analytics/dbt_utils
-    version: ">0.1.23"
+    version: 0.3.0


### PR DESCRIPTION
Last night dbt-utils made a breaking change. Can we lock this down temporarily.